### PR TITLE
fix bug where iOS doesn't unlock for SPAs

### DIFF
--- a/src/core/utils/touchLock.js
+++ b/src/core/utils/touchLock.js
@@ -22,11 +22,17 @@ export default function touchLock(context, callback) {
         callback();
     }
 
+    function addListeners() {
+        document.body.addEventListener('touchstart', unlock, false);
+        document.body.addEventListener('touchend', unlock, false);
+    }
+
     if (locked) {
-        document.addEventListener('DOMContentLoaded', () => {
-            document.body.addEventListener('touchstart', unlock, false);
-            document.body.addEventListener('touchend', unlock, false);
-        });
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', addListeners);
+        } else {
+            addListeners();
+        }
     }
 
     return locked;


### PR DESCRIPTION
adding touch event listeners also when readyState is already complete at time of loading sono (i.e. for SPAs)